### PR TITLE
Tweet Nacl, sponsor docstring, and stop logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-BrightID SDK for Applications
-===========================
+# BrightID SDK for Applications
 
 A typescript library for simplifying integration of applications with BrightID
 
@@ -10,9 +9,12 @@ Exposes all necessary functions for integrating an application with BrightID as 
 # ⚙ Install
 
 ```bash
-# npm
-yarn add https://github.com/BrightID/brightid-javascript-sdk.git
-npm i BrightID/brightid-javascript-sdk
+#npm
+npm i brightid_sdk_v6
+
+# yarn
+yarn add brightid_sdk_v6
+
 ```
 
 # 📖 Docs
@@ -30,8 +32,9 @@ Predefined scripts in `package.json`:
 - lint: lints your code
 - prepublishOnly: builds your sources for deployment (to npm)
 - size-limit: checks your bundle size limit
-- test: run tests 
+- test: run tests
 - upgrade-interactive: upgrades your dependencies interactively (like with yarn)
+
 # 📃 Licence
 
 Read the [licence](./LICENCE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-[brightid_sdk](README.md)
+[brightid_sdk_v6](README.md)
 
-# brightid_sdk
+# brightid_sdk_v6
 
 ## Index
 
@@ -26,7 +26,7 @@
 
 Ƭ **AppData**: *object*
 
-*Defined in [appMethods.ts:23](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L23)*
+*Defined in [appMethods.ts:23](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L23)*
 
 #### Type declaration:
 
@@ -72,7 +72,7 @@ ___
 
 Ƭ **SignedVerification**: *object*
 
-*Defined in [appMethods.ts:95](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L95)*
+*Defined in [appMethods.ts:95](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L95)*
 
 #### Type declaration:
 
@@ -98,7 +98,7 @@ ___
 
 Ƭ **SponsorData**: *object*
 
-*Defined in [appMethods.ts:180](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L180)*
+*Defined in [appMethods.ts:180](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L180)*
 
 #### Type declaration:
 
@@ -110,7 +110,7 @@ ___
 
 Ƭ **SponsorshipData**: *object*
 
-*Defined in [appMethods.ts:139](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L139)*
+*Defined in [appMethods.ts:139](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L139)*
 
 #### Type declaration:
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **generateDeeplink**(`app`: string, `appUserId`: string): *string*
 
-*Defined in [appMethods.ts:19](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L19)*
+*Defined in [appMethods.ts:19](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L19)*
 
 **Parameters:**
 
@@ -147,7 +147,7 @@ ___
 
 ▸ **getApp**(`app`: string): *Promise‹object›*
 
-*Defined in [appMethods.ts:50](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L50)*
+*Defined in [appMethods.ts:50](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L50)*
 
 **Parameters:**
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **sponsor**(`key`: string, `app`: string, `appUserId`: string): *Promise‹undefined | object | object›*
 
-*Defined in [appMethods.ts:192](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L192)*
+*Defined in [appMethods.ts:192](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L192)*
 
 **Parameters:**
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **unusedSponsorships**(`app`: string): *Promise‹undefined | number›*
 
-*Defined in [appMethods.ts:70](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L70)*
+*Defined in [appMethods.ts:70](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L70)*
 
 **Parameters:**
 
@@ -203,7 +203,7 @@ ___
 
 ▸ **userSponsorshipStatus**(`appUserId`: string): *Promise‹object›*
 
-*Defined in [appMethods.ts:152](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L152)*
+*Defined in [appMethods.ts:152](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L152)*
 
 **Parameters:**
 
@@ -221,7 +221,7 @@ ___
 
 ▸ **userVerificationStatus**(`app`: string, `appUserId`: string, `params?`: undefined | object): *Promise‹object›*
 
-*Defined in [appMethods.ts:114](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L114)*
+*Defined in [appMethods.ts:114](https://github.com/BrightID/brightIdSDK/blob/2720109/src/appMethods.ts#L114)*
 
 **Parameters:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@
 
 Ƭ **AppData**: *object*
 
-*Defined in [appMethods.ts:24](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L24)*
+*Defined in [appMethods.ts:23](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L23)*
 
 #### Type declaration:
 
@@ -72,7 +72,7 @@ ___
 
 Ƭ **SignedVerification**: *object*
 
-*Defined in [appMethods.ts:100](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L100)*
+*Defined in [appMethods.ts:95](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L95)*
 
 #### Type declaration:
 
@@ -98,7 +98,7 @@ ___
 
 Ƭ **SponsorData**: *object*
 
-*Defined in [appMethods.ts:189](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L189)*
+*Defined in [appMethods.ts:180](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L180)*
 
 #### Type declaration:
 
@@ -110,7 +110,7 @@ ___
 
 Ƭ **SponsorshipData**: *object*
 
-*Defined in [appMethods.ts:146](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L146)*
+*Defined in [appMethods.ts:139](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L139)*
 
 #### Type declaration:
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **generateDeeplink**(`app`: string, `appUserId`: string): *string*
 
-*Defined in [appMethods.ts:19](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L19)*
+*Defined in [appMethods.ts:19](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L19)*
 
 **Parameters:**
 
@@ -145,9 +145,9 @@ ___
 
 ### `Const` getApp
 
-▸ **getApp**(`app`: string): *Promise‹undefined | object | AxiosError‹any››*
+▸ **getApp**(`app`: string): *Promise‹object›*
 
-*Defined in [appMethods.ts:51](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L51)*
+*Defined in [appMethods.ts:50](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L50)*
 
 **Parameters:**
 
@@ -155,7 +155,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `app` | string | the BrightID unique app name to get information about  |
 
-**Returns:** *Promise‹undefined | object | AxiosError‹any››*
+**Returns:** *Promise‹object›*
 
 - Information about the BrightId app
 
@@ -163,19 +163,19 @@ ___
 
 ### `Const` sponsor
 
-▸ **sponsor**(`key`: string | Uint8Array, `app`: string, `appUserId`: string): *Promise‹any›*
+▸ **sponsor**(`key`: string, `app`: string, `appUserId`: string): *Promise‹undefined | object | object›*
 
-*Defined in [appMethods.ts:201](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L201)*
+*Defined in [appMethods.ts:192](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L192)*
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`key` | string &#124; Uint8Array | the sponsor private key needed for sponsoring a BrightID |
+`key` | string | the 64 byte private key attached to the {app} used to sponsor a BrightID |
 `app` | string | the application  in which to sponsor a given BrightID |
 `appUserId` | string | the appUserId linked to the BrightID user being sponsored  |
 
-**Returns:** *Promise‹any›*
+**Returns:** *Promise‹undefined | object | object›*
 
 A hash of the operation if successfully submitted to the BrightID node or an error
 
@@ -183,9 +183,9 @@ ___
 
 ### `Const` unusedSponsorships
 
-▸ **unusedSponsorships**(`app`: string): *Promise‹undefined | number | AxiosError‹any››*
+▸ **unusedSponsorships**(`app`: string): *Promise‹undefined | number›*
 
-*Defined in [appMethods.ts:73](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L73)*
+*Defined in [appMethods.ts:70](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L70)*
 
 **Parameters:**
 
@@ -193,7 +193,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `app` | string | the application to retrieve unused sponsorships for  |
 
-**Returns:** *Promise‹undefined | number | AxiosError‹any››*
+**Returns:** *Promise‹undefined | number›*
 
 Returns the number of sponsorships available to the specified `app`
 
@@ -201,9 +201,9 @@ ___
 
 ### `Const` userSponsorshipStatus
 
-▸ **userSponsorshipStatus**(`appUserId`: string): *Promise‹undefined | AxiosError‹any› | object›*
+▸ **userSponsorshipStatus**(`appUserId`: string): *Promise‹object›*
 
-*Defined in [appMethods.ts:159](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L159)*
+*Defined in [appMethods.ts:152](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L152)*
 
 **Parameters:**
 
@@ -211,7 +211,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `appUserId` | string | the appUserId string corresponding to a specific user in a BrightID app  |
 
-**Returns:** *Promise‹undefined | AxiosError‹any› | object›*
+**Returns:** *Promise‹object›*
 
 - the sponsorship status for the user
 
@@ -219,9 +219,9 @@ ___
 
 ### `Const` userVerificationStatus
 
-▸ **userVerificationStatus**(`app`: string, `appUserId`: string, `params?`: undefined | object): *Promise‹undefined | AxiosError‹any› | object›*
+▸ **userVerificationStatus**(`app`: string, `appUserId`: string, `params?`: undefined | object): *Promise‹object›*
 
-*Defined in [appMethods.ts:119](https://github.com/BrightID/brightIdSDK/blob/a07c711/src/appMethods.ts#L119)*
+*Defined in [appMethods.ts:114](https://github.com/BrightID/brightIdSDK/blob/cc5b88f/src/appMethods.ts#L114)*
 
 **Parameters:**
 
@@ -231,4 +231,4 @@ Name | Type | Description |
 `appUserId` | string | the appUserId string corresponding to a specific user in a BrightID app |
 `params?` | undefined &#124; object | the query parameters to pass to the signed verification endpoint  |
 
-**Returns:** *Promise‹undefined | AxiosError‹any› | object›*
+**Returns:** *Promise‹object›*

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "brightid_sdk",
-  "version": "2.0.0",
+  "name": "brightid_sdk_v6",
+  "version": "2.0.1",
   "licence": "MIT",
-  "author": {
-    "name": "acolytec3, Victor Ginelli (@youngkidwarrior)"
-  },
+  "authors": [
+    {
+      "name": "acolytec3"
+    },
+    {
+      "name": "Victor Ginelli (@youngkidwarrior)"
+    }
+  ],
   "main": "dist/index.js",
   "description": "A typescript library for simplifying integration of applications with BrightID",
   "keywords": [
@@ -21,10 +26,10 @@
     "test": "jest",
     "upgrade-interactive": "npm-check --update"
   },
-  "homepage": "https://github.com/acolytec3/brightIdSDK",
+  "homepage": "https://github.com/BrightID/brightid-javascript-sdk",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/acolytec3/brightIdSDK.git"
+    "url": "git+https://github.com/BrightID/brightid-javascript-sdk"
   },
   "husky": {
     "hooks": {

--- a/src/appMethods.ts
+++ b/src/appMethods.ts
@@ -7,7 +7,7 @@
 import axios from "axios";
 import stringify from "fast-json-stable-stringify";
 import B64 from "base64-js";
-import * as ed from "@noble/ed25519";
+import nacl from "tweetnacl";
 
 /**
  *
@@ -54,11 +54,9 @@ export const getApp = async (app: string) => {
     return res.data as AppData;
   } catch (err) {
     if (axios.isAxiosError(err)) {
-      console.error(err.response?.data);
-      return err;
+      throw err.response?.data;
     } else {
-      console.error(err);
-      return;
+      throw err;
     }
   }
 };
@@ -73,15 +71,13 @@ export const unusedSponsorships = async (app: string) => {
   const endpoint = "https://app.brightid.org/node/v6/apps";
   try {
     const res = await axios.get(`${endpoint}/${app}`);
-    const appData = res.data as AppData;
+    const appData = res.data.data as AppData;
     return appData.unusedSponsorships;
   } catch (err) {
     if (axios.isAxiosError(err)) {
-      console.error(err.response?.data);
-      return err;
+      throw err.response?.data;
     } else {
-      console.error(err);
-      return;
+      throw err;
     }
   }
 };
@@ -133,11 +129,9 @@ export const userVerificationStatus = async (
     return res.data as SignedVerification;
   } catch (err) {
     if (axios.isAxiosError(err)) {
-      console.error(err.response?.data);
-      return err;
+      throw err.response?.data;
     } else {
-      console.error(err);
-      return;
+      throw err;
     }
   }
 };
@@ -162,11 +156,9 @@ export const userSponsorshipStatus = async (appUserId: string) => {
     return res.data as SponsorshipData;
   } catch (err) {
     if (axios.isAxiosError(err)) {
-      console.error(err.response?.data);
-      return err;
+      throw err.response?.data;
     } else {
-      console.error(err);
-      return;
+      throw err;
     }
   }
 };
@@ -191,20 +183,16 @@ type SponsorData = {
 
 /**
  *
- * @param key - the sponsor private key needed for sponsoring a BrightID
+ * @param key - the 64 byte private key attached to the {app} used to sponsor a BrightID
  * @param app  - the application  in which to sponsor a given BrightID
  * @param appUserId - the appUserId linked to the BrightID user being sponsored
  *
  * @returns {SponsorData} A hash of the operation if successfully submitted to the BrightID node or an error
  */
-export const sponsor = async (
-  key: string | Uint8Array,
-  app: string,
-  appUserId: string
-) => {
+export const sponsor = async (key: string, app: string, appUserId: string) => {
   let endpoint = "http://app.brightid.org/node/v6/operation";
 
-  let sponsorships = unusedSponsorships(app);
+  let sponsorships = await unusedSponsorships(app);
 
   if (typeof sponsorships === "number" && sponsorships < 1)
     return { error: true, errorMessage: "No available sponsorships" };
@@ -223,20 +211,17 @@ export const sponsor = async (
 
   const message = getMessage(op);
   const arrayedMessage = Buffer.from(message);
-
+  const arrayedKey = B64.toByteArray(key);
+  const signature = nacl.sign.detached(arrayedMessage, arrayedKey);
+  op.sig = B64.fromByteArray(signature);
   try {
-    const signature = await ed.sign(arrayedMessage, key);
-    op.sig = B64.fromByteArray(signature);
-
     let res = await axios.post(endpoint, op);
     return res.data as SponsorData;
   } catch (err) {
     if (axios.isAxiosError(err)) {
-      console.error(err.response?.data);
-      return err;
+      throw err.response?.data;
     } else {
-      console.error(err);
-      return err;
+      throw err;
     }
   }
 };

--- a/src/appMethods.ts
+++ b/src/appMethods.ts
@@ -183,7 +183,7 @@ type SponsorData = {
 
 /**
  *
- * @param key - the 64 byte private key attached to the {app} used to sponsor a BrightID
+ * @param key - A Base64 string representation of the 64 byte sponsorship private key for the {app}
  * @param app  - the application  in which to sponsor a given BrightID
  * @param appUserId - the appUserId linked to the BrightID user being sponsored
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 import {
-  appInformation,
-  signedVerification,
-  sponsorshipInformation,
+  getApp,
+  unusedSponsorships,
+  userVerificationStatus,
+  userSponsorshipStatus,
+  sponsor,
 } from "./appMethods";
 
-export { appInformation, signedVerification, sponsorshipInformation };
+export {
+  getApp,
+  unusedSponsorships,
+  userVerificationStatus,
+  userSponsorshipStatus,
+  sponsor,
+};


### PR DESCRIPTION
 - Use tweetnacl to maintain parity with the rest of brightid
 - Remove all logs so we don't kill servers
 - Make sure sdk users know they will need a 64 byte string for the key